### PR TITLE
fix: use node 20 and add missing workdir on docker build

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         build_type: ['stable', 'develop']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build Element
         run: |

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -31,7 +31,7 @@ jobs:
           bash -ex ./scripts/appimage/02*.sh
 
       - name: Upload Appimage
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: element-${{ matrix.build_type }}
           path: '_dist'

--- a/patch.sh
+++ b/patch.sh
@@ -6,3 +6,9 @@ sed -i 's,import AutoLaunch from "auto-launch";,import AutoLaunch from "auto-lau
 sed -i "s,global.launcher.enable();,appimage.enableAutoStart();,g" src/electron-main.ts
 sed -i "s,global.launcher.disable(),appimage.disableAutoStart(),g" src/electron-main.ts
 sed -i "s,await oldLauncher.isEnabled(),appimage.isAutoStartEnabled(),g" src/electron-main.ts
+
+# fix docker build on element-desktop
+if ! grep -q WORKDIR dockerbuild/Dockerfile
+then
+  echo 'WORKDIR /project' >> dockerbuild/Dockerfile
+fi

--- a/patch.sh
+++ b/patch.sh
@@ -12,3 +12,6 @@ if ! grep -q WORKDIR dockerbuild/Dockerfile
 then
   echo 'WORKDIR /project' >> dockerbuild/Dockerfile
 fi
+
+# use Node 20 LTS on docker image
+sed -i 's,NODE_VERSION 18.19.*,NODE_VERSION 20.15.1,g' dockerbuild/Dockerfile

--- a/scripts/appimage/02-create_appimage.sh
+++ b/scripts/appimage/02-create_appimage.sh
@@ -43,7 +43,7 @@ yarn install
 sed -i 's,docker run --rm -ti,docker run --rm,g' scripts/in-docker.sh
 mkdir -p appimage_config
 pushd appimage_config
-if [[ "$BUILD_DEPS" == "stable" ]]; then 
+if [[ "$BUILD_TYPE" == "stable" ]]; then 
   wget https://app.element.io/config.json 
 else
   wget https://develop.element.io/config.json

--- a/scripts/appimage/02-create_appimage.sh
+++ b/scripts/appimage/02-create_appimage.sh
@@ -51,12 +51,12 @@ fi
 popd
 
 yarn run fetch --noverify --cfgdir 'appimage_config'
-yarn run docker:setup
 
 cp $RT/*.ts src/.
 cp $RT/patch.sh .
 ./patch.sh
 
+yarn run docker:setup
 yarn run docker:install < /dev/null
 yarn run docker:build:native
 yarn run docker:build


### PR DESCRIPTION
Hi,

There is 2 bugs on the Dockerfile in the element-desktop app.
I will see to fix it on the main repository, but as it can takes longer to be on the stable build, I added the fix on the patch script.

The issue started on this commit : https://github.com/element-hq/element-desktop/pull/1664/files#diff-9bb636bf9640838da44ea1e05710ad2aee398d4df07149c5d3bd0dc45bf6dfb9
It removes the WORKDIR on the dockerfile, so yarn run dont find the packages.json files.
Also, the development build need Node 20, and as it's the LTS current version and it builds on stable and dev version, I upgraded the dockerfile to use this version.

The patch file should be cleaned in the future when the fix in element-desktop repository will be deployed on a future stable version.

It will fix issue #11 
